### PR TITLE
Update firebase/php-jwt version constraint to include 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "blade-ui-kit/blade-icons": "^1.0",
-        "firebase/php-jwt": "^5.0 | ^6.0",
+        "firebase/php-jwt": "^5.0 | ^6.0 | ^7.0",
         "illuminate/contracts": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "blade-ui-kit/blade-icons": "^1.0",
-        "firebase/php-jwt": "^5.0 | ^6.0 | ^7.0",
+        "firebase/php-jwt": "^7.0",
         "illuminate/contracts": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },


### PR DESCRIPTION
v5.0 and v6.0 have the following CVE issues:

https://github.com/advisories/GHSA-2x45-7fc3-mxwq
https://github.com/advisories/GHSA-8xf4-w7qw-pjjw
https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/